### PR TITLE
add jade/wthit compatibility to 1.21.11 build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,12 @@ repositories {
 	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
 	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
 	// for more information about repositories.
+	maven {
+		url = "https://cursemaven.com"
+	}
+	maven {
+		url = "https://maven4.bai.lol"
+	}
 }
 
 loom {
@@ -111,6 +117,9 @@ dependencies {
 		implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 		implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 	}
+
+	modCompileOnly "mcp.mobius.waila:wthit-api:fabric-18.2.2"
+	modCompileOnly "curse.maven:jade-324717:7676480"
 	
 }
 

--- a/src/client/java_v1.21.11/mod/crackt/CracktClient.java
+++ b/src/client/java_v1.21.11/mod/crackt/CracktClient.java
@@ -22,9 +22,10 @@ public class CracktClient implements ClientModInitializer {
 				if (context.client().level.getBlockEntity(payload.pos()) instanceof CrackingClusterBlockEntity cluster) {
 					cluster.setDisplayState(payload.state());
 					cluster.setDisplayOffset(payload.offset());
+					cluster.setProgress(payload.hits(), payload.requiredHits());
 					return;
 				}
-				pendingClusterDisplays.put(payload.pos(), new ClusterDisplay(payload.state(), payload.offset()));
+				pendingClusterDisplays.put(payload.pos(), new ClusterDisplay(payload.state(), payload.offset(), payload.hits(), payload.requiredHits()));
 			});
 		});
 
@@ -40,6 +41,7 @@ public class CracktClient implements ClientModInitializer {
 				if (be instanceof CrackingClusterBlockEntity cluster) {
 					cluster.setDisplayState(entry.getValue().state());
 					cluster.setDisplayOffset(entry.getValue().offset());
+					cluster.setProgress(entry.getValue().hits(), entry.getValue().requiredHits());
 					ClientDisplayCache.put(entry.getKey(), entry.getValue().state());
 					return true;
 				}
@@ -48,5 +50,5 @@ public class CracktClient implements ClientModInitializer {
 		});
 	}
 
-	private record ClusterDisplay(net.minecraft.world.level.block.state.BlockState state, net.minecraft.world.phys.Vec3 offset) {}
+	private record ClusterDisplay(net.minecraft.world.level.block.state.BlockState state, net.minecraft.world.phys.Vec3 offset, int hits, int requiredHits) {}
 }

--- a/src/client/java_v1.21.11/mod/crackt/compat/JadeClientCompat.java
+++ b/src/client/java_v1.21.11/mod/crackt/compat/JadeClientCompat.java
@@ -1,0 +1,38 @@
+package mod.crackt.compat;
+
+import mod.crackt.Crackt;
+import mod.crackt.block.CrackingClusterBlockEntity;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.config.IPluginConfig;
+import snownee.jade.api.theme.IThemeHelper;
+
+import java.util.List;
+
+public class JadeClientCompat implements IBlockComponentProvider {
+	@Override
+	public net.minecraft.resources.Identifier getUid() {
+		return net.minecraft.resources.Identifier.fromNamespaceAndPath(Crackt.MOD_ID, "loot_preview");
+	}
+
+	@Override
+	public void appendTooltip(ITooltip tooltip, BlockAccessor accessor, IPluginConfig config) {
+		LootPreviewUtil.TooltipData data = LootPreviewUtil.readTooltipData(accessor.getServerData());
+		if (data.isEmpty()) {
+			return;
+		}
+
+		if (accessor.getBlockEntity() instanceof CrackingClusterBlockEntity) {
+			tooltip.clear();
+			tooltip.add(IThemeHelper.get().title(Component.translatable("tooltip.crackt.cracked_block", Component.translatable(data.displayNameKey()))));
+		}
+
+		tooltip.add(Component.translatable("tooltip.crackt.x_out_of_y_cracks", data.hits(), data.requiredHits()));
+		for (ItemStack stack : data.preview()) {
+			tooltip.add(stack.getHoverName().copy().append(" x" + stack.getCount()));
+		}
+	}
+}

--- a/src/client/java_v1.21.11/mod/crackt/compat/WthitClientCompat.java
+++ b/src/client/java_v1.21.11/mod/crackt/compat/WthitClientCompat.java
@@ -1,0 +1,70 @@
+package mod.crackt.compat;
+
+import mcp.mobius.waila.api.IBlockAccessor;
+import mcp.mobius.waila.api.IBlockComponentProvider;
+import mcp.mobius.waila.api.IClientRegistrar;
+import mcp.mobius.waila.api.IWailaConfig;
+import mcp.mobius.waila.api.IPluginConfig;
+import mcp.mobius.waila.api.ITooltip;
+import mcp.mobius.waila.api.WailaConstants;
+import mcp.mobius.waila.api.IWailaClientPlugin;
+import mcp.mobius.waila.api.component.ItemComponent;
+import mcp.mobius.waila.api.component.WrappedComponent;
+import mod.crackt.ClientDisplayCache;
+import mod.crackt.CracktBlocks;
+import mod.crackt.block.CrackingClusterBlockEntity;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.List;
+
+public class WthitClientCompat implements IWailaClientPlugin, IBlockComponentProvider {
+	private static final WthitClientCompat INSTANCE = new WthitClientCompat();
+
+	@Override
+	public void register(IClientRegistrar registrar) {
+		registrar.body(INSTANCE, Block.class);
+		registrar.head(INSTANCE, Block.class);
+	}
+
+	@Override
+	public void appendHead(ITooltip tooltip, IBlockAccessor accessor, IPluginConfig config) {
+		if (!accessor.getBlockState().is(CracktBlocks.CRACKING_CLUSTER)) {
+			return;
+		}
+		LootPreviewUtil.TooltipData data = LootPreviewUtil.readTooltipData(accessor.getData().raw());
+		if (data.isEmpty() && accessor.getBlockEntity() instanceof CrackingClusterBlockEntity cluster) {
+			data = new LootPreviewUtil.TooltipData(List.of(), cluster.getDisplayOrDefault().getBlock().getDescriptionId(), cluster.getHits(), cluster.getRequiredHits());
+		}
+		if (data.isEmpty()) {
+			BlockState cached = ClientDisplayCache.get(accessor.getPosition());
+			if (cached != null) {
+				data = new LootPreviewUtil.TooltipData(List.of(), cached.getBlock().getDescriptionId(), 0, 0);
+			}
+		}
+		if (data.isEmpty()) {
+			return;
+		}
+		Component title = Component.translatable("tooltip.crackt.cracked_block", Component.translatable(data.displayNameKey()));
+		tooltip.setLine(WailaConstants.OBJECT_NAME_TAG, IWailaConfig.get().getFormatter().blockName(title.getString()));
+	}
+
+	@Override
+	public void appendBody(ITooltip tooltip, IBlockAccessor accessor, IPluginConfig config) {
+		LootPreviewUtil.TooltipData syncedData = LootPreviewUtil.readTooltipData(accessor.getData().raw());
+		LootPreviewUtil.TooltipData data = syncedData;
+		if (data.isEmpty()) {
+			data = LootPreviewUtil.buildClientFallback(accessor.getLevel(), accessor.getPosition(), accessor.getBlockState());
+		}
+		if (data.isEmpty()) {
+			return;
+		}
+
+		tooltip.addLine(new WrappedComponent(net.minecraft.network.chat.Component.translatable("tooltip.crackt.x_out_of_y_cracks", data.hits(), data.requiredHits())));
+		for (ItemStack stack : syncedData.preview()) {
+			tooltip.addLine().with(new ItemComponent(stack));
+		}
+	}
+}

--- a/src/main/java_v1.21.11/mod/crackt/CracktNetworking.java
+++ b/src/main/java_v1.21.11/mod/crackt/CracktNetworking.java
@@ -30,19 +30,19 @@ public final class CracktNetworking {
 		// no-op for now
 	}
 
-	public static void syncCrackingCluster(ServerLevel level, BlockPos pos, BlockState state, net.minecraft.world.phys.Vec3 offset) {
-		CrackingClusterDisplay payload = new CrackingClusterDisplay(pos, state, offset);
+	public static void syncCrackingCluster(ServerLevel level, BlockPos pos, BlockState state, net.minecraft.world.phys.Vec3 offset, int hits, int requiredHits) {
+		CrackingClusterDisplay payload = new CrackingClusterDisplay(pos, state, offset, hits, requiredHits);
 		for (ServerPlayer player : PlayerLookup.tracking(level, pos)) {
 			ServerPlayNetworking.send(player, payload);
 		}
 	}
 
-	public record CrackingClusterDisplay(BlockPos pos, BlockState state, net.minecraft.world.phys.Vec3 offset) implements CustomPacketPayload {
+	public record CrackingClusterDisplay(BlockPos pos, BlockState state, net.minecraft.world.phys.Vec3 offset, int hits, int requiredHits) implements CustomPacketPayload {
 		public static final CustomPacketPayload.Type<CrackingClusterDisplay> ID = new CustomPacketPayload.Type<>(Identifier.fromNamespaceAndPath(Crackt.MOD_ID, "cracking_cluster_display"));
 		public static final StreamCodec<FriendlyByteBuf, CrackingClusterDisplay> CODEC = CustomPacketPayload.codec(CrackingClusterDisplay::write, CrackingClusterDisplay::new);
 
 		public CrackingClusterDisplay(FriendlyByteBuf buf) {
-			this(buf.readBlockPos(), Block.stateById(buf.readVarInt()), new net.minecraft.world.phys.Vec3(buf.readDouble(), buf.readDouble(), buf.readDouble()));
+			this(buf.readBlockPos(), Block.stateById(buf.readVarInt()), new net.minecraft.world.phys.Vec3(buf.readDouble(), buf.readDouble(), buf.readDouble()), buf.readVarInt(), buf.readVarInt());
 		}
 
 		private void write(FriendlyByteBuf buf) {
@@ -51,6 +51,8 @@ public final class CracktNetworking {
 			buf.writeDouble(offset.x);
 			buf.writeDouble(offset.y);
 			buf.writeDouble(offset.z);
+			buf.writeVarInt(hits);
+			buf.writeVarInt(requiredHits);
 		}
 
 		@Override

--- a/src/main/java_v1.21.11/mod/crackt/OreCracker.java
+++ b/src/main/java_v1.21.11/mod/crackt/OreCracker.java
@@ -48,6 +48,48 @@ public final class OreCracker {
 		PlayerBlockBreakEvents.AFTER.register(OreCracker::afterBreak);
 	}
 
+	public static boolean isPreviewTarget(BlockState state) {
+		return state.is(CracktBlocks.CRACKING_CLUSTER) || isOreBlock(state);
+	}
+
+	public static PreviewData getPreviewData(Level level, BlockPos pos, BlockState state) {
+		if (level.isClientSide()) {
+			return PreviewData.EMPTY;
+		}
+
+		boolean isCluster = state.is(CracktBlocks.CRACKING_CLUSTER);
+		if (!isCluster && !isOreBlock(state)) {
+			return PreviewData.EMPTY;
+		}
+
+		Session session = findSession(level, pos);
+		if (session == null) {
+			session = buildSession(level, pos, state, isCluster);
+		}
+		if (session == null) {
+			return PreviewData.EMPTY;
+		}
+
+		Map<BlockPos, BlockState> originals = session.collectPresentOriginals(level);
+		if (originals.isEmpty()) {
+			return PreviewData.EMPTY;
+		}
+
+		BlockState displayState = session.getOriginal(session.key().base());
+		if (displayState == null) {
+			displayState = session.anyOriginal();
+		}
+		if (displayState == null) {
+			displayState = state;
+		}
+
+		return new PreviewData(originals, displayState, session.hits(), session.requiredHits());
+	}
+
+	public static Map<BlockPos, BlockState> getPreviewOriginals(Level level, BlockPos pos, BlockState state) {
+		return getPreviewData(level, pos, state).originals();
+	}
+
 	private static boolean beforeBreak(Level level, Player player, BlockPos pos, BlockState state, /* nullable */ Object blockEntity) {
 		if (level.isClientSide()) return true;
 		if (PROCESSING.get()) return true;
@@ -255,10 +297,11 @@ public final class OreCracker {
 		if (level.getBlockEntity(base) instanceof CrackingClusterBlockEntity cluster) {
 			cluster.setDisplayState(original);
 			cluster.setDisplayOffset(session.offset());
+			cluster.setProgress(session.hits(), session.requiredHits());
 			cluster.setChanged();
 			// sync to clients
 			if (level instanceof net.minecraft.server.level.ServerLevel serverLevel) {
-				CracktNetworking.syncCrackingCluster(serverLevel, base, original, session.offset());
+				CracktNetworking.syncCrackingCluster(serverLevel, base, original, session.offset(), session.hits(), session.requiredHits());
 				level.sendBlockUpdated(base, previous, clusterState, Block.UPDATE_CLIENTS);
 				level.blockEntityChanged(base);
 			}
@@ -407,6 +450,14 @@ public final class OreCracker {
 
 	private record SessionKey(ResourceKey<Level> dimension, BlockPos base) {}
 
+	public record PreviewData(Map<BlockPos, BlockState> originals, BlockState displayState, int hits, int requiredHits) {
+		private static final PreviewData EMPTY = new PreviewData(Map.of(), Blocks.AIR.defaultBlockState(), 0, 0);
+
+		public boolean isEmpty() {
+			return originals.isEmpty();
+		}
+	}
+
 	private static final class Session {
 		private final SessionKey key;
 		private final Map<BlockPos, BlockState> originals;
@@ -451,12 +502,28 @@ public final class OreCracker {
 			return hits;
 		}
 
+		int requiredHits() {
+			return requiredHits;
+		}
+
 		int clusterStages() {
 			return clusterStages;
 		}
 
 		Vec3 offset() {
 			return offset;
+		}
+
+		Map<BlockPos, BlockState> collectPresentOriginals(Level level) {
+			Map<BlockPos, BlockState> present = new HashMap<>();
+			for (Map.Entry<BlockPos, BlockState> entry : originals.entrySet()) {
+				BlockPos pos = entry.getKey();
+				if (!pos.equals(key.base()) && !OreCracker.isOreBlock(level.getBlockState(pos))) {
+					continue;
+				}
+				present.put(pos.immutable(), entry.getValue());
+			}
+			return present;
 		}
 
 		/**

--- a/src/main/java_v1.21.11/mod/crackt/block/CrackingClusterBlockEntity.java
+++ b/src/main/java_v1.21.11/mod/crackt/block/CrackingClusterBlockEntity.java
@@ -21,6 +21,8 @@ import net.minecraft.world.phys.Vec3;
 public class CrackingClusterBlockEntity extends BlockEntity {
 	private BlockState displayState;
 	private Vec3 displayOffset = Vec3.ZERO;
+	private int hits;
+	private int requiredHits;
 
 	public CrackingClusterBlockEntity(BlockPos pos, BlockState state) {
 		super(CracktBlocks.CRACKING_CLUSTER_ENTITY, pos, state);
@@ -48,6 +50,20 @@ public class CrackingClusterBlockEntity extends BlockEntity {
 		setChanged();
 	}
 
+	public int getHits() {
+		return hits;
+	}
+
+	public int getRequiredHits() {
+		return requiredHits;
+	}
+
+	public void setProgress(int hits, int requiredHits) {
+		this.hits = hits;
+		this.requiredHits = requiredHits;
+		setChanged();
+	}
+
 	private BlockState defaultState() {
 		return Blocks.IRON_ORE.defaultBlockState();
 	}
@@ -63,6 +79,12 @@ public class CrackingClusterBlockEntity extends BlockEntity {
 			writer.putDouble("off_y", displayOffset.y);
 			writer.putDouble("off_z", displayOffset.z);
 		}
+		if (hits > 0) {
+			writer.putInt("hits", hits);
+		}
+		if (requiredHits > 0) {
+			writer.putInt("required_hits", requiredHits);
+		}
 	}
 
 	@Override
@@ -74,6 +96,8 @@ public class CrackingClusterBlockEntity extends BlockEntity {
 		double oy = reader.getDoubleOr("off_y", 0.0);
 		double oz = reader.getDoubleOr("off_z", 0.0);
 		displayOffset = new Vec3(ox, oy, oz);
+		hits = reader.getIntOr("hits", 0);
+		requiredHits = reader.getIntOr("required_hits", 0);
 	}
 
 	@Override

--- a/src/main/java_v1.21.11/mod/crackt/compat/JadeCompat.java
+++ b/src/main/java_v1.21.11/mod/crackt/compat/JadeCompat.java
@@ -1,0 +1,46 @@
+package mod.crackt.compat;
+
+import mod.crackt.Crackt;
+import snownee.jade.api.IBlockComponentProvider;
+import snownee.jade.api.IWailaClientRegistration;
+import snownee.jade.api.IWailaCommonRegistration;
+import snownee.jade.api.IWailaPlugin;
+import snownee.jade.api.WailaPlugin;
+
+@WailaPlugin
+public class JadeCompat implements IWailaPlugin {
+	@Override
+	public void register(IWailaCommonRegistration registrar) {
+		registrar.registerBlockDataProvider(new JadeCommonProvider(), net.minecraft.world.level.block.Block.class);
+	}
+
+	@Override
+	public void registerClient(IWailaClientRegistration registrar) {
+		IBlockComponentProvider provider;
+		try {
+			provider = (IBlockComponentProvider) Class.forName("mod.crackt.compat.JadeClientCompat").getDeclaredConstructor().newInstance();
+		} catch (ReflectiveOperationException exception) {
+			throw new IllegalStateException("Failed to load Jade client compat", exception);
+		}
+		registrar.registerBlockComponent(provider, net.minecraft.world.level.block.Block.class);
+	}
+
+	private static final class JadeCommonProvider implements snownee.jade.api.IServerDataProvider<snownee.jade.api.BlockAccessor> {
+		@Override
+		public void appendServerData(net.minecraft.nbt.CompoundTag data, snownee.jade.api.BlockAccessor accessor) {
+			if (!(accessor.getLevel() instanceof net.minecraft.server.level.ServerLevel level)) {
+				return;
+			}
+			net.minecraft.world.level.block.state.BlockState state = accessor.getBlockState();
+			if (!LootPreviewUtil.shouldShow(state)) {
+				return;
+			}
+			LootPreviewUtil.writePreview(data, level, accessor.getPosition(), state, accessor.getPlayer());
+		}
+
+		@Override
+		public net.minecraft.resources.Identifier getUid() {
+			return net.minecraft.resources.Identifier.fromNamespaceAndPath(Crackt.MOD_ID, "loot_preview");
+		}
+	}
+}

--- a/src/main/java_v1.21.11/mod/crackt/compat/LootPreviewUtil.java
+++ b/src/main/java_v1.21.11/mod/crackt/compat/LootPreviewUtil.java
@@ -1,0 +1,231 @@
+package mod.crackt.compat;
+
+import mod.crackt.CracktBlocks;
+import mod.crackt.OreCracker;
+import mod.crackt.block.CrackingClusterBlockEntity;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.Identifier;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.ArrayList;
+import java.util.ArrayDeque;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class LootPreviewUtil {
+	private static final String PREVIEW_KEY = "crackt_loot_preview";
+	private static final String DISPLAY_NAME_KEY = "display_name";
+	private static final String HITS_KEY = "hits";
+	private static final String REQUIRED_HITS_KEY = "required_hits";
+	private static final String ITEM_KEY = "item";
+	private static final String COUNT_KEY = "count";
+
+	private LootPreviewUtil() {}
+
+	public static boolean shouldShow(BlockState state) {
+		return OreCracker.isPreviewTarget(state);
+	}
+
+	public static void writePreview(CompoundTag data, ServerLevel level, BlockPos pos, BlockState state, Player player) {
+		OreCracker.PreviewData previewData = OreCracker.getPreviewData(level, pos, state);
+		if (previewData.isEmpty()) {
+			return;
+		}
+
+		data.putString(DISPLAY_NAME_KEY, previewData.displayState().getBlock().getDescriptionId());
+		data.putInt(HITS_KEY, previewData.hits());
+		data.putInt(REQUIRED_HITS_KEY, previewData.requiredHits());
+
+		List<ItemStack> preview = collectPreview(level, previewData, player);
+
+		ListTag entries = new ListTag();
+		for (ItemStack stack : preview) {
+			if (stack.isEmpty()) {
+				continue;
+			}
+			CompoundTag entry = new CompoundTag();
+			entry.putString(ITEM_KEY, BuiltInRegistries.ITEM.getKey(stack.getItem()).toString());
+			entry.putInt(COUNT_KEY, stack.getCount());
+			entries.add(entry);
+		}
+		if (!entries.isEmpty()) {
+			data.put(PREVIEW_KEY, entries);
+		}
+	}
+
+	public static TooltipData readTooltipData(CompoundTag data) {
+		ListTag entries = data.getListOrEmpty(PREVIEW_KEY);
+		List<ItemStack> preview = new ArrayList<>(entries.size());
+		for (Tag tag : entries) {
+			if (!(tag instanceof CompoundTag entry)) {
+				continue;
+			}
+			String rawId = entry.getString(ITEM_KEY).orElse(null);
+			Identifier id = rawId == null ? null : Identifier.tryParse(rawId);
+			if (id == null) {
+				continue;
+			}
+			Item item = BuiltInRegistries.ITEM.getValue(id);
+			int count = entry.getIntOr(COUNT_KEY, 0);
+			if (item == Items.AIR || count <= 0) {
+				continue;
+			}
+			preview.add(new ItemStack(item, count));
+		}
+		String displayNameKey = data.getStringOr(DISPLAY_NAME_KEY, Blocks.IRON_ORE.getDescriptionId());
+		int hits = data.getIntOr(HITS_KEY, 0);
+		int requiredHits = data.getIntOr(REQUIRED_HITS_KEY, 0);
+		if (preview.isEmpty() && requiredHits <= 0) {
+			return TooltipData.EMPTY;
+		}
+		return new TooltipData(preview, displayNameKey, hits, requiredHits);
+	}
+
+	public static TooltipData buildClientFallback(Level level, BlockPos pos, BlockState state) {
+		Map<BlockPos, BlockState> originals = scanConnectedPreview(level, pos, state);
+		if (originals.isEmpty()) {
+			return TooltipData.EMPTY;
+		}
+
+		Block targetBlock = resolveTargetBlock(level, pos, state);
+		CrackingClusterBlockEntity cluster = findConnectedCluster(level, pos, targetBlock);
+		Map<Item, Integer> totals = new HashMap<>();
+		for (BlockState original : originals.values()) {
+			Item item = original.getBlock().asItem();
+			if (item == Items.AIR) {
+				continue;
+			}
+			totals.merge(item, 1, Integer::sum);
+		}
+
+		List<ItemStack> preview = totals.entrySet().stream()
+			.sorted(Comparator.comparing(entry -> BuiltInRegistries.ITEM.getKey(entry.getKey()).toString()))
+			.map(entry -> new ItemStack(entry.getKey(), entry.getValue()))
+			.toList();
+
+		int hits = cluster != null ? cluster.getHits() : 0;
+		int requiredHits = cluster != null && cluster.getRequiredHits() > 0 ? cluster.getRequiredHits() : OreCracker.computeRequiredCracks(originals.size());
+		String displayName = cluster != null ? cluster.getDisplayOrDefault().getBlock().getDescriptionId() : targetBlock.getDescriptionId();
+		return new TooltipData(preview, displayName, hits, requiredHits);
+	}
+
+	private static Map<BlockPos, BlockState> scanConnectedPreview(Level level, BlockPos origin, BlockState state) {
+		Block targetBlock = resolveTargetBlock(level, origin, state);
+		if (!OreCracker.isPreviewTarget(state)) {
+			return Map.of();
+		}
+
+		Map<BlockPos, BlockState> originals = new HashMap<>();
+		Deque<BlockPos> queue = new ArrayDeque<>();
+		queue.add(origin);
+		while (!queue.isEmpty()) {
+			BlockPos current = queue.removeFirst();
+			if (originals.containsKey(current)) {
+				continue;
+			}
+
+			BlockState currentState = level.getBlockState(current);
+			BlockState original = originalStateForPreview(level, currentState, current);
+			if (original == null || original.getBlock() != targetBlock) {
+				continue;
+			}
+			originals.put(current.immutable(), original);
+
+			for (BlockPos offset : neighborOffsets()) {
+				BlockPos next = current.offset(offset);
+				if (!originals.containsKey(next)) {
+					queue.add(next);
+				}
+			}
+		}
+		return originals;
+	}
+
+	private static Block resolveTargetBlock(Level level, BlockPos pos, BlockState state) {
+		if (state.is(CracktBlocks.CRACKING_CLUSTER) && level.getBlockEntity(pos) instanceof CrackingClusterBlockEntity cluster) {
+			return cluster.getDisplayOrDefault().getBlock();
+		}
+		return state.getBlock();
+	}
+
+	private static CrackingClusterBlockEntity findConnectedCluster(Level level, BlockPos origin, Block targetBlock) {
+		for (Map.Entry<BlockPos, BlockState> entry : scanConnectedPreview(level, origin, level.getBlockState(origin)).entrySet()) {
+			if (level.getBlockEntity(entry.getKey()) instanceof CrackingClusterBlockEntity cluster && cluster.getDisplayOrDefault().getBlock() == targetBlock) {
+				return cluster;
+			}
+		}
+		return null;
+	}
+
+	private static BlockState originalStateForPreview(Level level, BlockState state, BlockPos pos) {
+		if (state.is(CracktBlocks.CRACKING_CLUSTER)) {
+			if (level.getBlockEntity(pos) instanceof CrackingClusterBlockEntity cluster) {
+				return cluster.getDisplayOrDefault();
+			}
+			return null;
+		}
+		return OreCracker.isPreviewTarget(state) ? state : null;
+	}
+
+	private static BlockPos[] neighborOffsets() {
+		return new BlockPos[] {
+			new BlockPos(1, 0, 0),
+			new BlockPos(-1, 0, 0),
+			new BlockPos(0, 1, 0),
+			new BlockPos(0, -1, 0),
+			new BlockPos(0, 0, 1),
+			new BlockPos(0, 0, -1)
+		};
+	}
+
+	private static List<ItemStack> collectPreview(ServerLevel level, OreCracker.PreviewData previewData, Player player) {
+		Map<Item, Integer> totals = new HashMap<>();
+		ItemStack tool = player.getMainHandItem();
+		for (Map.Entry<BlockPos, BlockState> entry : previewData.originals().entrySet()) {
+			for (ItemStack drop : Block.getDrops(entry.getValue(), level, entry.getKey(), getLootBlockEntity(level, entry.getKey(), entry.getValue()), player, tool)) {
+				if (drop.isEmpty()) {
+					continue;
+				}
+				totals.merge(drop.getItem(), drop.getCount(), Integer::sum);
+			}
+		}
+
+		return totals.entrySet().stream()
+			.sorted(Comparator.comparing(entry -> BuiltInRegistries.ITEM.getKey(entry.getKey()).toString()))
+			.map(entry -> new ItemStack(entry.getKey(), entry.getValue()))
+			.toList();
+	}
+
+	private static BlockEntity getLootBlockEntity(ServerLevel level, BlockPos pos, BlockState originalState) {
+		BlockEntity blockEntity = level.getBlockEntity(pos);
+		if (blockEntity instanceof CrackingClusterBlockEntity && !originalState.is(CracktBlocks.CRACKING_CLUSTER)) {
+			return null;
+		}
+		return blockEntity;
+	}
+
+	public record TooltipData(List<ItemStack> preview, String displayNameKey, int hits, int requiredHits) {
+		private static final TooltipData EMPTY = new TooltipData(List.of(), Blocks.AIR.getDescriptionId(), 0, 0);
+
+		public boolean isEmpty() {
+			return preview.isEmpty() && requiredHits <= 0;
+		}
+	}
+}

--- a/src/main/java_v1.21.11/mod/crackt/compat/WthitCommonCompat.java
+++ b/src/main/java_v1.21.11/mod/crackt/compat/WthitCommonCompat.java
@@ -1,0 +1,37 @@
+package mod.crackt.compat;
+
+import mcp.mobius.waila.api.ICommonRegistrar;
+import mcp.mobius.waila.api.IDataProvider;
+import mcp.mobius.waila.api.IDataWriter;
+import mcp.mobius.waila.api.IPluginConfig;
+import mcp.mobius.waila.api.IServerAccessor;
+import mcp.mobius.waila.api.IWailaCommonPlugin;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class WthitCommonCompat implements IWailaCommonPlugin, IDataProvider {
+	private static final WthitCommonCompat INSTANCE = new WthitCommonCompat();
+
+	@Override
+	public void register(ICommonRegistrar registrar) {
+		registrar.blockData(INSTANCE, Block.class);
+	}
+
+	@Override
+	public void appendData(IDataWriter data, IServerAccessor accessor, IPluginConfig config) {
+		if (!(accessor.getLevel() instanceof ServerLevel level)) {
+			return;
+		}
+		if (!(accessor.getHitResult() instanceof BlockHitResult hitResult)) {
+			return;
+		}
+		BlockState state = level.getBlockState(hitResult.getBlockPos());
+		if (!LootPreviewUtil.shouldShow(state)) {
+			return;
+		}
+		LootPreviewUtil.writePreview(data.raw(), level, hitResult.getBlockPos(), state, accessor.getPlayer());
+	}
+}

--- a/src/main/resources/assets/crackt/lang/en_us.json
+++ b/src/main/resources/assets/crackt/lang/en_us.json
@@ -1,0 +1,4 @@
+{
+	"tooltip.crackt.cracked_block": "Cracked %s",
+	"tooltip.crackt.x_out_of_y_cracks": "%s/%s cracks"
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,6 +20,9 @@
 		],
 		"client": [
 			"mod.crackt.CracktClient"
+		],
+		"jade": [
+			"mod.crackt.compat.JadeCompat"
 		]
 	},
 	"mixins": [

--- a/src/main/resources/waila_plugins.json
+++ b/src/main/resources/waila_plugins.json
@@ -1,0 +1,9 @@
+{
+	"crackt:plugin": {
+		"entrypoints": {
+			"common": "mod.crackt.compat.WthitCommonCompat",
+			"client": "mod.crackt.compat.WthitClientCompat"
+		},
+		"side": "*"
+	}
+}


### PR DESCRIPTION
Addresses #5 by adding Jade/WTHIT compatibility for the 1.21.11 build

<img width="2550" height="2095" alt="2026-05-10_12 28 38" src="https://github.com/user-attachments/assets/a48f810d-0d53-4f89-86ed-12b2042ec778" />
<img width="2550" height="2095" alt="2026-05-10_12 28 53" src="https://github.com/user-attachments/assets/15a4461f-7284-4c00-a5d4-3b126a8fcf29" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ItsJustMeChris/codesmith/crackt/pr/6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->